### PR TITLE
Fix deserialization of missing nullable fields

### DIFF
--- a/src/Hangfire.Mongo/Dto/DistributedLockDto.cs
+++ b/src/Hangfire.Mongo/Dto/DistributedLockDto.cs
@@ -22,7 +22,10 @@ namespace Hangfire.Mongo.Dto
         public DistributedLockDto(BsonDocument doc)
         {
             Id = doc["_id"].AsObjectId;
-            Resource = doc[nameof(Resource)].StringOrNull();
+            if (doc.TryGetValue(nameof(Resource), out var resource))
+            {
+                Resource = resource.StringOrNull();
+            }
             ExpireAt = doc[nameof(ExpireAt)].ToUniversalTime();
         }
         /// <summary>

--- a/src/Hangfire.Mongo/Dto/JobDto.cs
+++ b/src/Hangfire.Mongo/Dto/JobDto.cs
@@ -19,11 +19,26 @@ namespace Hangfire.Mongo.Dto
                 return;
             }
 
-            Queue = doc[nameof(Queue)].StringOrNull();
-            FetchedAt = doc[nameof(FetchedAt)].ToNullableLocalTime();
-            StateName = doc[nameof(StateName)].StringOrNull();
-            InvocationData = doc[nameof(InvocationData)].StringOrNull();
-            Arguments = doc[nameof(Arguments)].StringOrNull();
+            if (doc.TryGetValue(nameof(Queue), out var queue))
+            {
+                Queue = queue.StringOrNull();
+            }
+            if (doc.TryGetValue(nameof(FetchedAt), out var fetchedAt))
+            {
+                FetchedAt = fetchedAt.ToNullableLocalTime();
+            }
+            if (doc.TryGetValue(nameof(StateName), out var stateName))
+            {
+                StateName = stateName.StringOrNull();
+            }
+            if (doc.TryGetValue(nameof(InvocationData), out var invocationData))
+            {
+                InvocationData = invocationData.StringOrNull();
+            }
+            if (doc.TryGetValue(nameof(Arguments), out var arguments))
+            {
+                Arguments = arguments.StringOrNull();
+            }
             Parameters = new Dictionary<string, string>();
             if (doc.TryGetValue(nameof(Parameters), out var parameters))
             {

--- a/src/Hangfire.Mongo/Dto/KeyJobDto.cs
+++ b/src/Hangfire.Mongo/Dto/KeyJobDto.cs
@@ -19,7 +19,10 @@ namespace Hangfire.Mongo.Dto
             {
                 return;
             }
-            Key = doc[nameof(Key)].StringOrNull();
+            if (doc.TryGetValue(nameof(Key), out var key))
+            {
+                Key = key.StringOrNull();
+            }
         }
 
         protected override void Serialize(BsonDocument document)

--- a/src/Hangfire.Mongo/Dto/ListDto.cs
+++ b/src/Hangfire.Mongo/Dto/ListDto.cs
@@ -11,8 +11,14 @@ namespace Hangfire.Mongo.Dto
         }
         public ListDto(BsonDocument doc) : base(doc)
         {
-            Item = doc[nameof(Item)].StringOrNull();
-            Value = doc[nameof(Value)].StringOrNull();
+            if (doc.TryGetValue(nameof(Item), out var item))
+            {
+                Item = item.StringOrNull();
+            }
+            if (doc.TryGetValue(nameof(Value), out var value))
+            {
+                Value = value.StringOrNull();
+            }
         }
         public string Item { get; set; }
 

--- a/src/Hangfire.Mongo/Dto/NotificationDto.cs
+++ b/src/Hangfire.Mongo/Dto/NotificationDto.cs
@@ -29,7 +29,10 @@ namespace Hangfire.Mongo.Dto
         {
             Id = doc["_id"].AsObjectId;
             Type = (NotificationType)doc[nameof(Type)].AsInt32;
-            Value = doc[nameof(Value)].StringOrNull();
+            if (doc.TryGetValue(nameof(Value), out var value))
+            {
+                Value = value.StringOrNull();
+            }
         }
 
         [BsonId]

--- a/src/Hangfire.Mongo/Dto/ServerDto.cs
+++ b/src/Hangfire.Mongo/Dto/ServerDto.cs
@@ -15,9 +15,18 @@ namespace Hangfire.Mongo.Dto
         {
             Id = doc["_id"].AsString;
             WorkerCount = doc[nameof(WorkerCount)].AsInt32;
-            Queues = doc[nameof(Queues)].AsBsonArray.Select(q => q.StringOrNull()).ToArray();
-            StartedAt = doc[nameof(StartedAt)].ToNullableUniversalTime();
-            LastHeartbeat = doc[nameof(LastHeartbeat)].ToNullableUniversalTime();
+            if (doc.TryGetValue(nameof(Queues), out var queues))
+            {
+                Queues = queues.AsBsonArray.Select(q => q.StringOrNull()).ToArray();
+            }
+            if (doc.TryGetValue(nameof(StartedAt), out var startedAt))
+            {
+                StartedAt = startedAt.ToNullableUniversalTime();
+            }
+            if (doc.TryGetValue(nameof(LastHeartbeat), out var lastHeartbeat))
+            {
+                LastHeartbeat = lastHeartbeat.ToNullableUniversalTime();
+            }
         }
         public string Id { get; set; }
 

--- a/src/Hangfire.Mongo/Dto/SetDto.cs
+++ b/src/Hangfire.Mongo/Dto/SetDto.cs
@@ -17,8 +17,14 @@ namespace Hangfire.Mongo.Dto
             }
 
             Score = doc[nameof(Score)].AsDouble;
-            Value = doc[nameof(Value)].StringOrNull();
-            SetType = doc[nameof(SetType)].StringOrNull();
+            if (doc.TryGetValue(nameof(Value), out var value))
+            {
+                Value = value.StringOrNull();
+            }
+            if (doc.TryGetValue(nameof(SetType), out var setType))
+            {
+                SetType = setType.StringOrNull();
+            }
         }
         public double Score { get; set; }
 

--- a/src/Hangfire.Mongo/Dto/StateDto.cs
+++ b/src/Hangfire.Mongo/Dto/StateDto.cs
@@ -13,8 +13,14 @@ namespace Hangfire.Mongo.Dto
         }
         public StateDto(BsonDocument doc)
         {
-            Name = doc[nameof(Name)].StringOrNull();
-            Reason = doc[nameof(Reason)].StringOrNull();
+            if (doc.TryGetValue(nameof(Name), out var name))
+            {
+                Name = name.StringOrNull();
+            }
+            if (doc.TryGetValue(nameof(Reason), out var reason))
+            {
+                Reason = reason.StringOrNull();
+            }
             CreatedAt = doc[nameof(CreatedAt)].ToUniversalTime();
             Data = new Dictionary<string, string>();
             if(doc.TryGetValue(nameof(Data), out var data))

--- a/src/Hangfire.Mongo/Migration/Steps/Version20/00_RemoveJobQueueDto.cs
+++ b/src/Hangfire.Mongo/Migration/Steps/Version20/00_RemoveJobQueueDto.cs
@@ -44,7 +44,7 @@ namespace Hangfire.Mongo.Migration.Steps.Version20
                                                 ["$set"] = new BsonDocument
                                                 {
                                                     ["Queue"] = jobQueue["Queue"],
-                                                    ["FetchedAt"] = jobQueue["FetchedAt"]
+                                                    ["FetchedAt"] = jobQueue.TryGetValue("FetchedAt", out var fetchedAt) ? fetchedAt : BsonNull.Value
                                                 }
                                             }
                                         ));


### PR DESCRIPTION
This fixes https://github.com/gottscj/Hangfire.Mongo/issues/394 and generally provides support for deserializing nullable fields that are missing in the database due to `IgnoreIfNullConvention(true)` having been active at the point in time that the data was written.