### PR TITLE
feat(mongo): Update mongo driver to v3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,13 @@ on:
   pull_request:
     branches: [ master ]
 
+env:
+  DOTNET_CLI_TELEMETRY_OPTOUT: true
+  DOTNET_NOLOGO: true
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+  DOTNET_USE_POLLING_FILE_WATCHER: true
+  NUGET_XMLDOC_MODE: skip
+
 jobs:
   build:
 
@@ -11,10 +18,15 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v3
+    - name: Cache NuGet Packages
+      uses: actions/cache@v4
       with:
-        dotnet-version: 8.0.x
+        key: nuget-cache
+        path: ~/.nuget/packages
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 8
 
     - name: Restore dependencies
       run: dotnet restore ./src

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,9 +20,14 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Setup .NET
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 8.0.x
+    - name: Cache NuGet Packages
+      uses: actions/cache@v4
+      with:
+        key: nuget-cache
+        path: ~/.nuget/packages
 
     - name: Restore dependencies
       run: dotnet restore ./src
@@ -33,9 +38,8 @@ jobs:
     - name: Test
       run: dotnet test ./src -c Release --no-build --verbosity normal
 
-
     - name: Create a Release
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@v2
       with:
           token: ${{ secrets.GITHUB_TOKEN }}
           name: Release ${{ github.event.inputs.version }}

--- a/src/Hangfire.Mongo.Sample.ASPNetCore/Hangfire.Mongo.Sample.ASPNetCore.csproj
+++ b/src/Hangfire.Mongo.Sample.ASPNetCore/Hangfire.Mongo.Sample.ASPNetCore.csproj
@@ -23,9 +23,9 @@
     <PackageReference Include="Hangfire.AspNetCore" Version="1.8.14" />
     <PackageReference Include="Hangfire.Core" Version="1.8.14" />
     <PackageReference Include="jquery" Version="3.7.1" />
-    <PackageReference Include="Mongo2Go" Version="3.1.3" />
-    <PackageReference Include="MongoDB.Driver" Version="2.29.0" />
+    <PackageReference Include="MongoDB.Driver" Version="3.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
+    <PackageReference Include="Testcontainers.MongoDb" Version="3.10.0" />
   </ItemGroup>
 </Project>

--- a/src/Hangfire.Mongo.Sample.ASPNetCore/MongoRunner.cs
+++ b/src/Hangfire.Mongo.Sample.ASPNetCore/MongoRunner.cs
@@ -1,45 +1,27 @@
 using System;
-using System.IO;
+using System.Threading.Tasks;
+using Testcontainers.MongoDb;
 
 namespace Hangfire.Mongo.Sample.ASPNetCore
 {
-    public class MongoRunner : IDisposable
+    public class MongoTestRunner : IAsyncDisposable
     {
-        private Mongo2Go.MongoDbRunner _runner;
+        public readonly MongoDbContainer MongoDbContainer =
+            new MongoDbBuilder()
+                .WithImage("mongo:7.0")
+                .Build();
 
-        public string ConnectionString => _runner?.ConnectionString;
-        public MongoRunner Start()
+        public string MongoConnectionString { get; private set; }
+
+        public async Task Start()
         {
-            var homePath = Environment.OSVersion.Platform is PlatformID.Unix or PlatformID.MacOSX
-                ? Environment.GetEnvironmentVariable("HOME")
-                : Environment.ExpandEnvironmentVariables("%HOMEDRIVE%%HOMEPATH%");
-
-            if (string.IsNullOrEmpty(homePath))
-            {
-                throw new InvalidOperationException("Could not locate home path");
-            }
-            var dataDir = Path.Combine(homePath, "mongodb", "data");
-            for (int i = 0; i < 3; i++)
-            {
-                try
-                {
-                    _runner = Mongo2Go.MongoDbRunner.StartForDebugging(
-                        singleNodeReplSet: true,
-                        dataDirectory: dataDir);
-                }
-                catch (Exception e)
-                {
-                    Console.WriteLine(e);
-                }
-            }
-            
-
-            return this;
+            await MongoDbContainer.StartAsync();
+            MongoConnectionString = MongoDbContainer.GetConnectionString();
         }
 
-        public void Dispose()
+        public async ValueTask DisposeAsync()
         {
-            _runner?.Dispose();
+            if (MongoDbContainer != null) await MongoDbContainer.DisposeAsync();
         }
     }
 }

--- a/src/Hangfire.Mongo.Sample.ASPNetCore/MyRecurringjob.cs
+++ b/src/Hangfire.Mongo.Sample.ASPNetCore/MyRecurringjob.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Diagnostics;
 using System.Threading;
 
 namespace Hangfire.Mongo.Sample.ASPNetCore;

--- a/src/Hangfire.Mongo.Sample.ASPNetCore/Program.cs
+++ b/src/Hangfire.Mongo.Sample.ASPNetCore/Program.cs
@@ -1,6 +1,5 @@
 ﻿using System.IO;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.Extensions.Logging;
 
 namespace Hangfire.Mongo.Sample.ASPNetCore
 {

--- a/src/Hangfire.Mongo.Sample.ASPNetCore/Startup.cs
+++ b/src/Hangfire.Mongo.Sample.ASPNetCore/Startup.cs
@@ -30,14 +30,13 @@ namespace Hangfire.Mongo.Sample.ASPNetCore
         public void ConfigureServices(IServiceCollection services)
         {
             // Add framework services.
-            services.AddHangfire(config =>
+            services.AddHangfire(async config =>
             {
-
-                var runner = new MongoRunner().Start();
-                services.AddSingleton(runner);
+                await using var mongoTestRunner = new MongoTestRunner();
+                await mongoTestRunner.Start();
 
                 // Read DefaultConnection string from appsettings.json
-                var mongoUrlBuilder = new MongoUrlBuilder(runner.ConnectionString)
+                var mongoUrlBuilder = new MongoUrlBuilder(mongoTestRunner.MongoConnectionString)
                 {
                     DatabaseName = "hangfire"
                 };

--- a/src/Hangfire.Mongo.Sample.CosmosDB/Hangfire.Mongo.Sample.CosmosDB.csproj
+++ b/src/Hangfire.Mongo.Sample.CosmosDB/Hangfire.Mongo.Sample.CosmosDB.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="Hangfire.AspNetCore" Version="1.8.14" />
     <PackageReference Include="Hangfire.Core" Version="1.8.14" />
     <PackageReference Include="jquery" Version="3.7.1" />
-    <PackageReference Include="MongoDB.Driver" Version="2.29.0" />
+    <PackageReference Include="MongoDB.Driver" Version="3.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
   </ItemGroup>

--- a/src/Hangfire.Mongo.Sample.NETCore/Hangfire.Mongo.Sample.NETCore.csproj
+++ b/src/Hangfire.Mongo.Sample.NETCore/Hangfire.Mongo.Sample.NETCore.csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Hangfire.Core" Version="1.8.14" />
-    <PackageReference Include="Mongo2Go" Version="3.1.3" />
-    <PackageReference Include="MongoDB.Driver" Version="2.29.0" />
+    <PackageReference Include="MongoDB.Driver" Version="3.0.0" />
+    <PackageReference Include="Testcontainers.MongoDb" Version="3.10.0" />
   </ItemGroup>
 </Project>

--- a/src/Hangfire.Mongo.Sample.NETCore/Program.cs
+++ b/src/Hangfire.Mongo.Sample.NETCore/Program.cs
@@ -1,8 +1,8 @@
 ﻿using System;
+using System.Threading.Tasks;
 using Hangfire.Logging.LogProviders;
 using Hangfire.Mongo.Migration.Strategies;
 using Hangfire.Mongo.Migration.Strategies.Backup;
-using MongoDB.Bson.Serialization.Conventions;
 using MongoDB.Driver;
 
 namespace Hangfire.Mongo.Sample.NETCore
@@ -11,7 +11,7 @@ namespace Hangfire.Mongo.Sample.NETCore
     {
         private const int JobCount = 100;
 
-        public static void Main()
+        public static async Task Main()
         {
             var migrationOptions = new MongoStorageOptions
             {
@@ -24,10 +24,11 @@ namespace Hangfire.Mongo.Sample.NETCore
             };
 
             GlobalConfiguration.Configuration.UseLogProvider(new ColouredConsoleLogProvider());
-            using var runner = new MongoRunner().Start();
-            
+            await using var mongoTestRunner = new MongoTestRunner();
+            await mongoTestRunner.Start();
+
             JobStorage.Current = new MongoStorage(
-                MongoClientSettings.FromConnectionString(runner.ConnectionString), 
+                MongoClientSettings.FromConnectionString(mongoTestRunner.MongoConnectionString),
                 databaseName: "Mongo-Hangfire-Sample-NETCore",
                 migrationOptions);
 

--- a/src/Hangfire.Mongo.Tests/ExpirationManagerFacts.cs
+++ b/src/Hangfire.Mongo.Tests/ExpirationManagerFacts.cs
@@ -5,7 +5,6 @@ using Hangfire.Mongo.Database;
 using Hangfire.Mongo.Dto;
 using Hangfire.Mongo.Tests.Utils;
 using MongoDB.Bson;
-using MongoDB.Driver;
 using Xunit;
 
 namespace Hangfire.Mongo.Tests
@@ -17,7 +16,7 @@ namespace Hangfire.Mongo.Tests
         private readonly HangfireDbContext _dbContext;
         private readonly CancellationToken _token;
 
-        public ExpirationManagerFacts(MongoDbFixture fixture)
+        public ExpirationManagerFacts(MongoIntegrationTestFixture fixture)
         {
             fixture.CleanDatabase();
             _dbContext = fixture.CreateDbContext();

--- a/src/Hangfire.Mongo.Tests/Hangfire.Mongo.Tests.csproj
+++ b/src/Hangfire.Mongo.Tests/Hangfire.Mongo.Tests.csproj
@@ -27,10 +27,10 @@
     <ProjectReference Include="../Hangfire.Mongo/Hangfire.Mongo.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="EphemeralMongo6" Version="1.1.3" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="NSubstitute" Version="5.1.0" />
+    <PackageReference Include="Testcontainers.MongoDb" Version="3.10.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Hangfire.Mongo.Tests/Migration/Mongo/MigrationFacts.cs
+++ b/src/Hangfire.Mongo.Tests/Migration/Mongo/MigrationFacts.cs
@@ -20,9 +20,9 @@ namespace Hangfire.Mongo.Tests.Migration.Mongo
     [Collection("Database")]
     public class MigrationFacts
     {
-        private readonly MongoDbFixture _fixture;
+        private readonly MongoIntegrationTestFixture _fixture;
 
-        public MigrationFacts(MongoDbFixture fixture)
+        public MigrationFacts(MongoIntegrationTestFixture fixture)
         {
             fixture.CleanDatabase();
             _fixture = fixture;

--- a/src/Hangfire.Mongo.Tests/Migration/Mongo/MongoDatabaseFiller.cs
+++ b/src/Hangfire.Mongo.Tests/Migration/Mongo/MongoDatabaseFiller.cs
@@ -19,9 +19,9 @@ namespace Hangfire.Mongo.Tests.Migration.Mongo
     [Collection("Database")]
     public class MongoDatabaseFiller
     {
-        private readonly MongoDbFixture _fixture;
+        private readonly MongoIntegrationTestFixture _fixture;
 
-        public MongoDatabaseFiller(MongoDbFixture fixture)
+        public MongoDatabaseFiller(MongoIntegrationTestFixture fixture)
         {
             _fixture = fixture;
         }

--- a/src/Hangfire.Mongo.Tests/Migration/Version15MigrationStepFacts.cs
+++ b/src/Hangfire.Mongo.Tests/Migration/Version15MigrationStepFacts.cs
@@ -17,7 +17,7 @@ namespace Hangfire.Mongo.Tests.Migration
         private readonly HangfireDbContext _dbContext;
         private readonly IMongoDatabase _database;
 
-        public Version15MigrationStepFacts(MongoDbFixture fixture)
+        public Version15MigrationStepFacts(MongoIntegrationTestFixture fixture)
         {
             _dbContext = fixture.CreateDbContext();
             _database = _dbContext.Database;

--- a/src/Hangfire.Mongo.Tests/Migration/Version16MigrationStepFacts.cs
+++ b/src/Hangfire.Mongo.Tests/Migration/Version16MigrationStepFacts.cs
@@ -14,7 +14,7 @@ namespace Hangfire.Mongo.Tests.Migration
         private readonly HangfireDbContext _dbContext;
         private readonly IMongoDatabase _database;
 
-        public Version16MigrationStepFacts(MongoDbFixture fixture)
+        public Version16MigrationStepFacts(MongoIntegrationTestFixture fixture)
         {
             _dbContext = fixture.CreateDbContext();
             _database = _dbContext.Database;

--- a/src/Hangfire.Mongo.Tests/Migration/Version18MigrationStepFacts.cs
+++ b/src/Hangfire.Mongo.Tests/Migration/Version18MigrationStepFacts.cs
@@ -14,7 +14,7 @@ namespace Hangfire.Mongo.Tests.Migration
     {
         private readonly IMongoDatabase _database;
 
-        public Version18MigrationStepFacts(MongoDbFixture fixture)
+        public Version18MigrationStepFacts(MongoIntegrationTestFixture fixture)
         {
             var dbContext = fixture.CreateDbContext();
             _database = dbContext.Database;

--- a/src/Hangfire.Mongo.Tests/Migration/Version19MigrationStepFacts.cs
+++ b/src/Hangfire.Mongo.Tests/Migration/Version19MigrationStepFacts.cs
@@ -15,7 +15,7 @@ namespace Hangfire.Mongo.Tests.Migration
         private readonly IMongoDatabase _database;
         private readonly Random _random;
         private readonly AddTypeToSetDto _addTypeToSetDto;
-        public Version19MigrationStepFacts(MongoDbFixture fixture)
+        public Version19MigrationStepFacts(MongoIntegrationTestFixture fixture)
         {
             var dbContext = fixture.CreateDbContext();
             _database = dbContext.Database;

--- a/src/Hangfire.Mongo.Tests/Migration/Version20MigrationStepFacts.cs
+++ b/src/Hangfire.Mongo.Tests/Migration/Version20MigrationStepFacts.cs
@@ -16,7 +16,7 @@ namespace Hangfire.Mongo.Tests.Migration
     {
         private readonly IMongoDatabase _database;
         private readonly IMongoMigrationStep _migration;
-        public Version20MigrationStepFacts(MongoDbFixture fixture)
+        public Version20MigrationStepFacts(MongoIntegrationTestFixture fixture)
         {
             var dbContext = fixture.CreateDbContext();
             _database = dbContext.Database;

--- a/src/Hangfire.Mongo.Tests/MongoConnectionFacts.cs
+++ b/src/Hangfire.Mongo.Tests/MongoConnectionFacts.cs
@@ -24,7 +24,7 @@ namespace Hangfire.Mongo.Tests
         private readonly MongoConnection _connection;
 		private readonly IJobQueueSemaphore _jobQueueSemaphoreMock;
 
-        public MongoConnectionFacts(MongoDbFixture fixture)
+        public MongoConnectionFacts(MongoIntegrationTestFixture fixture)
         {
             _jobQueueSemaphoreMock = Substitute.For<IJobQueueSemaphore>();
             var storageOptions = new MongoStorageOptions

--- a/src/Hangfire.Mongo.Tests/MongoDiscriminatorTests.cs
+++ b/src/Hangfire.Mongo.Tests/MongoDiscriminatorTests.cs
@@ -1,13 +1,10 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using Hangfire.Common;
 using Hangfire.Mongo.Database;
 using Hangfire.Mongo.Dto;
 using Hangfire.Mongo.Tests.Utils;
 using MongoDB.Bson;
-using MongoDB.Bson.Serialization;
 using MongoDB.Bson.Serialization.Conventions;
 using MongoDB.Driver;
 using Xunit;
@@ -19,7 +16,7 @@ namespace Hangfire.Mongo.Tests
     {
         private readonly HangfireDbContext _dbContext;
 
-        public MongoDiscriminatorTests(MongoDbFixture fixture)
+        public MongoDiscriminatorTests(MongoIntegrationTestFixture fixture)
         {
             _dbContext = fixture.CreateDbContext();
         }

--- a/src/Hangfire.Mongo.Tests/MongoDistributedLockFacts.cs
+++ b/src/Hangfire.Mongo.Tests/MongoDistributedLockFacts.cs
@@ -18,7 +18,7 @@ namespace Hangfire.Mongo.Tests
     {
         private readonly HangfireDbContext _database;
 
-        public MongoDistributedLockFacts(MongoDbFixture fixture)
+        public MongoDistributedLockFacts(MongoIntegrationTestFixture fixture)
         {
             fixture.CleanDatabase();
             _database = fixture.CreateDbContext();

--- a/src/Hangfire.Mongo.Tests/MongoFetchedJobFacts.cs
+++ b/src/Hangfire.Mongo.Tests/MongoFetchedJobFacts.cs
@@ -21,7 +21,7 @@ namespace Hangfire.Mongo.Tests
         private readonly DateTime _fetchedAt = DateTime.UtcNow;
         private readonly HangfireDbContext _dbContext;
 
-        public MongoFetchedJobFacts(MongoDbFixture fixture)
+        public MongoFetchedJobFacts(MongoIntegrationTestFixture fixture)
         {
             fixture.CleanDatabase();
             _dbContext = fixture.CreateDbContext();

--- a/src/Hangfire.Mongo.Tests/MongoJobQueueFacts.cs
+++ b/src/Hangfire.Mongo.Tests/MongoJobQueueFacts.cs
@@ -19,7 +19,7 @@ namespace Hangfire.Mongo.Tests
         private readonly IJobQueueSemaphore _jobQueueSemaphoreMock;
         private readonly HangfireDbContext _hangfireDbContext;
 
-        public MongoJobQueueFacts(MongoDbFixture fixture)
+        public MongoJobQueueFacts(MongoIntegrationTestFixture fixture)
         {
             _jobQueueSemaphoreMock = Substitute.For<IJobQueueSemaphore>();
             _jobQueueSemaphoreMock.WaitAny(DefaultQueues, default, default, out _, out _)

--- a/src/Hangfire.Mongo.Tests/MongoMonitoringApiFacts.cs
+++ b/src/Hangfire.Mongo.Tests/MongoMonitoringApiFacts.cs
@@ -23,7 +23,7 @@ namespace Hangfire.Mongo.Tests
         private readonly HangfireDbContext _database;
         private readonly MongoMonitoringApi _monitoringApi;
 
-        public MongoMonitoringApiFacts(MongoDbFixture fixture)
+        public MongoMonitoringApiFacts(MongoIntegrationTestFixture fixture)
         {
             fixture.CleanDatabase();
             _database = fixture.CreateDbContext();

--- a/src/Hangfire.Mongo.Tests/MongoNotificationObserverErrorFacts.cs
+++ b/src/Hangfire.Mongo.Tests/MongoNotificationObserverErrorFacts.cs
@@ -17,7 +17,7 @@ namespace Hangfire.Mongo.Tests
         private readonly IJobQueueSemaphore _jobQueueSemaphoreMock;
         private readonly CancellationTokenSource _cts;
 
-        public MongoNotificationObserverErrorFacts(MongoDbFixture fixture)
+        public MongoNotificationObserverErrorFacts(MongoIntegrationTestFixture fixture)
         {
             _dbContext = fixture.CreateDbContext();
             _jobQueueSemaphoreMock = Substitute.For<IJobQueueSemaphore>();

--- a/src/Hangfire.Mongo.Tests/MongoNotificationObserverFacts.cs
+++ b/src/Hangfire.Mongo.Tests/MongoNotificationObserverFacts.cs
@@ -18,7 +18,7 @@ namespace Hangfire.Mongo.Tests
         private readonly IJobQueueSemaphore _jobQueueSemaphoreMock;
         private readonly CancellationTokenSource _cts;
 
-        public MongoNotificationObserverFacts(MongoDbFixture fixture)
+        public MongoNotificationObserverFacts(MongoIntegrationTestFixture fixture)
         {
             _dbContext = fixture.CreateDbContext();
             _jobQueueSemaphoreMock = Substitute.For<IJobQueueSemaphore>();

--- a/src/Hangfire.Mongo.Tests/MongoRunServerFacts.cs
+++ b/src/Hangfire.Mongo.Tests/MongoRunServerFacts.cs
@@ -38,7 +38,7 @@ namespace Hangfire.Mongo.Tests
         private readonly BackgroundJobServer _server;
         public HangfireDbContext DbContext { get; }
 
-        public MongoRunFixture(MongoDbFixture fixture)
+        public MongoRunFixture(MongoIntegrationTestFixture fixture)
         {
             var databaseName = "Mongo-Hangfire-CamelCase";
             var context = fixture.CreateDbContext(databaseName);

--- a/src/Hangfire.Mongo.Tests/MongoStorageFacts.cs
+++ b/src/Hangfire.Mongo.Tests/MongoStorageFacts.cs
@@ -13,7 +13,7 @@ namespace Hangfire.Mongo.Tests
     {
         private readonly MongoStorage _storage;
 
-        public MongoStorageFacts(MongoDbFixture fixture)
+        public MongoStorageFacts(MongoIntegrationTestFixture fixture)
         {
             fixture.CleanDatabase();
             _storage = fixture.CreateStorage();

--- a/src/Hangfire.Mongo.Tests/MongoVersionHelperFacts.cs
+++ b/src/Hangfire.Mongo.Tests/MongoVersionHelperFacts.cs
@@ -12,9 +12,9 @@ namespace Hangfire.Mongo.Tests
     [Collection("Database")]
     public class MongoVersionHelperFacts
     {
-        private readonly MongoDbFixture _fixture;
+        private readonly MongoIntegrationTestFixture _fixture;
 
-        public MongoVersionHelperFacts(MongoDbFixture fixture) => _fixture = fixture;
+        public MongoVersionHelperFacts(MongoIntegrationTestFixture fixture) => _fixture = fixture;
 
         [Fact]
         public void GetVersion_HasAdditionalInfo_Success()

--- a/src/Hangfire.Mongo.Tests/MongoWatcherFacts.cs
+++ b/src/Hangfire.Mongo.Tests/MongoWatcherFacts.cs
@@ -18,7 +18,7 @@ namespace Hangfire.Mongo.Tests
         private readonly IJobQueueSemaphore _jobQueueSemaphoreMock;
         private readonly CancellationTokenSource _cts;
 
-        public MongoWatcherFacts(MongoDbFixture fixture)
+        public MongoWatcherFacts(MongoIntegrationTestFixture fixture)
         {
             _dbContext = fixture.CreateDbContext();
             _jobQueueSemaphoreMock = Substitute.For<IJobQueueSemaphore>();
@@ -66,7 +66,7 @@ namespace Hangfire.Mongo.Tests
                     [nameof(JobDto.Queue)] = "test"
                 }
             });
-            signal.Wait(100000);
+            signal.Wait(20000);
 
             // ASSERT
             _jobQueueSemaphoreMock.Received(1).Release("test");

--- a/src/Hangfire.Mongo.Tests/MongoWriteOnlyTransactionFacts.cs
+++ b/src/Hangfire.Mongo.Tests/MongoWriteOnlyTransactionFacts.cs
@@ -18,7 +18,7 @@ namespace Hangfire.Mongo.Tests
     {
         private readonly HangfireDbContext _database;
 
-        public MongoWriteOnlyTransactionFacts(MongoDbFixture fixture)
+        public MongoWriteOnlyTransactionFacts(MongoIntegrationTestFixture fixture)
         {
             fixture.CleanDatabase();
             _database = fixture.CreateDbContext();

--- a/src/Hangfire.Mongo.Tests/MultipleServersFacts.cs
+++ b/src/Hangfire.Mongo.Tests/MultipleServersFacts.cs
@@ -12,7 +12,7 @@ namespace Hangfire.Mongo.Tests
     {
         private readonly MongoStorage _storage;
 
-        public MultipleServersFacts(MongoDbFixture fixture)
+        public MultipleServersFacts(MongoIntegrationTestFixture fixture)
         {
             fixture.CleanDatabase();
             _storage = fixture.CreateStorage(new MongoStorageOptions { QueuePollInterval = TimeSpan.FromSeconds(1) });

--- a/src/Hangfire.Mongo.Tests/Utils/DatabaseCollection.cs
+++ b/src/Hangfire.Mongo.Tests/Utils/DatabaseCollection.cs
@@ -3,7 +3,7 @@
 namespace Hangfire.Mongo.Tests.Utils
 {
     [CollectionDefinition("Database")]
-    public class DatabaseCollection : ICollectionFixture<MongoDbFixture>
+    public class DatabaseCollection : ICollectionFixture<MongoIntegrationTestFixture>
     {
     }
 }

--- a/src/Hangfire.Mongo/CosmosDB/CosmosDbWriteOnlyTransaction.cs
+++ b/src/Hangfire.Mongo/CosmosDB/CosmosDbWriteOnlyTransaction.cs
@@ -1,11 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using Hangfire.Common;
 using Hangfire.Logging;
 using Hangfire.Mongo.Database;
 using Hangfire.Mongo.Dto;
-using Hangfire.Storage;
 using MongoDB.Bson;
 using MongoDB.Driver;
 

--- a/src/Hangfire.Mongo/CosmosDB/CosmosQueueWatcher.cs
+++ b/src/Hangfire.Mongo/CosmosDB/CosmosQueueWatcher.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Threading;
+﻿using System.Threading;
 using Hangfire.Logging;
 using Hangfire.Mongo.Database;
 using Hangfire.Mongo.Dto;

--- a/src/Hangfire.Mongo/Dto/ExpiringJobDto.cs
+++ b/src/Hangfire.Mongo/Dto/ExpiringJobDto.cs
@@ -1,8 +1,5 @@
 ﻿using System;
 using MongoDB.Bson;
-using MongoDB.Bson.IO;
-using MongoDB.Bson.Serialization;
-using MongoDB.Bson.Serialization.Attributes;
 
 namespace Hangfire.Mongo.Dto
 {

--- a/src/Hangfire.Mongo/Dto/HashDto.cs
+++ b/src/Hangfire.Mongo/Dto/HashDto.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using MongoDB.Bson;
-using MongoDB.Bson.Serialization.Attributes;
 
 namespace Hangfire.Mongo.Dto
 {

--- a/src/Hangfire.Mongo/Dto/KeyJobDto.cs
+++ b/src/Hangfire.Mongo/Dto/KeyJobDto.cs
@@ -1,5 +1,4 @@
 ﻿using MongoDB.Bson;
-using MongoDB.Bson.Serialization.Attributes;
 
 namespace Hangfire.Mongo.Dto
 {

--- a/src/Hangfire.Mongo/Dto/MigrationLockDto.cs
+++ b/src/Hangfire.Mongo/Dto/MigrationLockDto.cs
@@ -1,6 +1,5 @@
 using System;
 using MongoDB.Bson;
-using MongoDB.Bson.Serialization.Attributes;
 
 namespace Hangfire.Mongo.Dto
 {

--- a/src/Hangfire.Mongo/Dto/SerializeExtensions.cs
+++ b/src/Hangfire.Mongo/Dto/SerializeExtensions.cs
@@ -1,7 +1,4 @@
 ﻿using MongoDB.Bson;
-using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Hangfire.Mongo.Dto
 {

--- a/src/Hangfire.Mongo/Hangfire.Mongo.csproj
+++ b/src/Hangfire.Mongo/Hangfire.Mongo.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>netstandard2.0</TargetFramework>
+        <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard2.1;net6.0;net8.0</TargetFrameworks>
+        <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">net472;netstandard2.1;net6.0;net8.0</TargetFrameworks>
         <NoWarn>$(NoWarn);CS0618</NoWarn>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -11,8 +12,8 @@
         <owners>Sergey Zwezdin, Jonas Gottschau</owners>
         <Description>MongoDB storage implementation for Hangfire (background job system for ASP.NET applications).</Description>
         <PackageTags>Hangfire AspNet OWIN MongoDB CosmosDB Long-Running Background Fire-And-Forget Delayed Recurring Tasks Jobs Scheduler Threading Queues</PackageTags>
-        <PackageReleaseNotes>1.10.9            
-            - Update to MongoDB 2.29.0
+        <PackageReleaseNotes>1.11.0
+            - Update to MongoDB 3.0
         </PackageReleaseNotes>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <!--<PackageLicenseUrl>https://raw.githubusercontent.com/sergun/Hangfire.Mongo/master/LICENSE</PackageLicenseUrl>-->
@@ -25,7 +26,7 @@
     </ItemGroup>
     <ItemGroup>
         <PackageReference Include="Hangfire.Core" Version="1.8.14" />
-        <PackageReference Include="MongoDB.Driver" Version="2.29.0" />
+        <PackageReference Include="MongoDB.Driver" Version="3.0.0" />
     </ItemGroup>
     <ItemGroup>
         <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">

--- a/src/Hangfire.Mongo/Migration/MigrationLock.cs
+++ b/src/Hangfire.Mongo/Migration/MigrationLock.cs
@@ -17,7 +17,7 @@ namespace Hangfire.Mongo.Migration
         private readonly IMongoCollection<BsonDocument> _migrationLock;
 
         private readonly BsonDocument _migrationIdFilter =
-            new BsonDocument("_id", new BsonObjectId("5c351d07197a9bcdba4832fc"));
+            new BsonDocument("_id", new BsonObjectId(ObjectId.Parse("5c351d07197a9bcdba4832fc")));
         
         /// <summary>
         /// ctor

--- a/src/Hangfire.Mongo/Migration/Steps/Version07/01_EnqueuedJobMigration.cs
+++ b/src/Hangfire.Mongo/Migration/Steps/Version07/01_EnqueuedJobMigration.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Linq;
+﻿using System.Linq;
 using MongoDB.Bson;
 using MongoDB.Driver;
 

--- a/src/Hangfire.Mongo/Migration/Steps/Version09/00_CreateSignalCollection.cs
+++ b/src/Hangfire.Mongo/Migration/Steps/Version09/00_CreateSignalCollection.cs
@@ -1,5 +1,4 @@
-﻿using Hangfire.Mongo.CosmosDB;
-using MongoDB.Driver;
+﻿using MongoDB.Driver;
 
 namespace Hangfire.Mongo.Migration.Steps.Version09
 {

--- a/src/Hangfire.Mongo/Migration/Steps/Version13/00_CombineJobsAndStateData.cs
+++ b/src/Hangfire.Mongo/Migration/Steps/Version13/00_CombineJobsAndStateData.cs
@@ -1,8 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using Hangfire.Mongo.Dto;
 using MongoDB.Bson;
 using MongoDB.Driver;
 

--- a/src/Hangfire.Mongo/Migration/Steps/Version15/03_RemoveMergedCounters.cs
+++ b/src/Hangfire.Mongo/Migration/Steps/Version15/03_RemoveMergedCounters.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using MongoDB.Bson;
 using MongoDB.Driver;

--- a/src/Hangfire.Mongo/Migration/Steps/Version17/00_AddNotificationsCollection.cs
+++ b/src/Hangfire.Mongo/Migration/Steps/Version17/00_AddNotificationsCollection.cs
@@ -1,4 +1,3 @@
-using Hangfire.Mongo.CosmosDB;
 using MongoDB.Driver;
 
 namespace Hangfire.Mongo.Migration.Steps.Version17

--- a/src/Hangfire.Mongo/Migration/Steps/Version20/01_CompoundIndexes.cs
+++ b/src/Hangfire.Mongo/Migration/Steps/Version20/01_CompoundIndexes.cs
@@ -1,5 +1,4 @@
-﻿using System.Threading.Tasks;
-using MongoDB.Bson;
+﻿using MongoDB.Bson;
 using MongoDB.Driver;
 
 namespace Hangfire.Mongo.Migration.Steps.Version20

--- a/src/Hangfire.Mongo/Migration/Steps/Version21/00_AddIndexesMigration.cs
+++ b/src/Hangfire.Mongo/Migration/Steps/Version21/00_AddIndexesMigration.cs
@@ -1,7 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-using Hangfire.Mongo.Dto;
-using MongoDB.Bson;
+﻿using MongoDB.Bson;
 using MongoDB.Driver;
 
 namespace Hangfire.Mongo.Migration.Steps.Version21

--- a/src/Hangfire.Mongo/Migration/Strategies/Backup/NoneMongoBackupStrategy.cs
+++ b/src/Hangfire.Mongo/Migration/Strategies/Backup/NoneMongoBackupStrategy.cs
@@ -1,6 +1,4 @@
-﻿using MongoDB.Driver;
-
-namespace Hangfire.Mongo.Migration.Strategies.Backup
+﻿namespace Hangfire.Mongo.Migration.Strategies.Backup
 {
     /// <summary>
     /// No backup strategy

--- a/src/Hangfire.Mongo/MongoExpirationManager.cs
+++ b/src/Hangfire.Mongo/MongoExpirationManager.cs
@@ -6,7 +6,6 @@ using Hangfire.Mongo.Dto;
 using Hangfire.Mongo.Migration;
 using Hangfire.Server;
 using MongoDB.Bson;
-using MongoDB.Driver;
 
 namespace Hangfire.Mongo
 {

--- a/src/Hangfire.Mongo/MongoWriteOnlyTransaction.cs
+++ b/src/Hangfire.Mongo/MongoWriteOnlyTransaction.cs
@@ -543,34 +543,34 @@ namespace Hangfire.Mongo
                     serializedDoc = ((InsertOneModel<BsonDocument>) writeModel).Document.ToJson();
                     break;
                 case WriteModelType.DeleteOne:
-                    serializedDoc = ((DeleteOneModel<BsonDocument>) writeModel).Filter.Render(serializer, registry)
+                    serializedDoc = ((DeleteOneModel<BsonDocument>) writeModel).Filter.Render(new RenderArgs<BsonDocument>(serializer, registry))
                         .ToJson();
                     break;
                 case WriteModelType.DeleteMany:
-                    serializedDoc = ((DeleteManyModel<BsonDocument>) writeModel).Filter.Render(serializer, registry)
+                    serializedDoc = ((DeleteManyModel<BsonDocument>) writeModel).Filter.Render(new RenderArgs<BsonDocument>(serializer, registry))
                         .ToJson();
                     break;
                 case WriteModelType.ReplaceOne:
 
                     serializedDoc = new Dictionary<string, BsonDocument>
                     {
-                        ["Filter"] = ((ReplaceOneModel<BsonDocument>) writeModel).Filter.Render(serializer, registry),
+                        ["Filter"] = ((ReplaceOneModel<BsonDocument>) writeModel).Filter.Render(new RenderArgs<BsonDocument>(serializer, registry)),
                         ["Replacement"] = ((ReplaceOneModel<BsonDocument>) writeModel).Replacement
                     }.ToJson();
                     break;
                 case WriteModelType.UpdateOne:
                     serializedDoc = new Dictionary<string, BsonDocument>
                     {
-                        ["Filter"] = ((UpdateOneModel<BsonDocument>) writeModel).Filter.Render(serializer, registry),
-                        ["Update"] = ((UpdateOneModel<BsonDocument>) writeModel).Update.Render(serializer, registry)
+                        ["Filter"] = ((UpdateOneModel<BsonDocument>) writeModel).Filter.Render(new RenderArgs<BsonDocument>(serializer, registry)),
+                        ["Update"] = ((UpdateOneModel<BsonDocument>) writeModel).Update.Render(new RenderArgs<BsonDocument>(serializer, registry))
                             .AsBsonDocument
                     }.ToJson();
                     break;
                 case WriteModelType.UpdateMany:
                     serializedDoc = new Dictionary<string, BsonDocument>
                     {
-                        ["Filter"] = ((UpdateManyModel<BsonDocument>) writeModel).Filter.Render(serializer, registry),
-                        ["Update"] = ((UpdateManyModel<BsonDocument>) writeModel).Update.Render(serializer, registry)
+                        ["Filter"] = ((UpdateManyModel<BsonDocument>) writeModel).Filter.Render(new RenderArgs<BsonDocument>(serializer, registry)),
+                        ["Update"] = ((UpdateManyModel<BsonDocument>) writeModel).Update.Render(new RenderArgs<BsonDocument>(serializer, registry))
                             .AsBsonDocument
                     }.ToJson();
                     break;


### PR DESCRIPTION
* Ephemeral mongo won't work with the v3 driver and mongo2go fails.
* Replaced with Testcontainers.MongoDb
* Removed unused usings
* Dropped netstandard 2.0 as mongo 3.0 removed target; it does support net472 but would require library to be built on windows agent
* Update actions versions

Tests pass bar the MongoWatcherFacts; literally no idea what that's supposed to be testing.
Watching the mongo db the data written in the test is committed.

![image](https://github.com/user-attachments/assets/3a4083e9-a4b9-4256-acad-4ce803e5a3b5)


I'd say this is a breaking change as Mongo v3 drops support for netstandard2.0
They have kept net472 but that would probably require some fettling with the github actions. For now I've simply set the target for either

```
<TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard2.1;net6.0;net8.0</TargetFrameworks>
<TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">net472;netstandard2.1;net6.0;net8.0</TargetFrameworks>
```


