### PR TITLE
Add UTC time support for AWS DocumentDB compatibility

### DIFF
--- a/src/Hangfire.Mongo.Tests/MongoConnectionFacts.cs
+++ b/src/Hangfire.Mongo.Tests/MongoConnectionFacts.cs
@@ -16,12 +16,13 @@ using Xunit;
 
 namespace Hangfire.Mongo.Tests
 {
+#pragma warning disable 1591
     [Collection("Database")]
     public class MongoConnectionFacts
     {
         private readonly HangfireDbContext _dbContext;
         private readonly MongoConnection _connection;
-		private readonly IJobQueueSemaphore _jobQueueSemaphoreMock;
+        private readonly IJobQueueSemaphore _jobQueueSemaphoreMock;
 
         public MongoConnectionFacts(MongoIntegrationTestFixture fixture)
         {
@@ -568,7 +569,7 @@ namespace Hangfire.Mongo.Tests
                 WorkerCount = 1000
             };
             _connection.AnnounceServer("server", context2);
-            var sameServer =  new ServerDto(_dbContext.Server.AsQueryable().Single());
+            var sameServer = new ServerDto(_dbContext.Server.AsQueryable().Single());
             Assert.Equal("server", sameServer.Id);
             Assert.Equal(context2.WorkerCount, sameServer.WorkerCount);
         }
@@ -1553,8 +1554,8 @@ namespace Hangfire.Mongo.Tests
         public void GetUtcDateTime_FromConnection_Success()
         {
             // Arrange
-            _dbContext.Schema.InsertOne(new SchemaDto{Version = MongoSchema.None}.Serialize());
-            
+            _dbContext.Schema.InsertOne(new SchemaDto { Version = MongoSchema.None }.Serialize());
+
             // Act
             var serverTime = _connection.GetUtcDateTime();
 
@@ -1601,7 +1602,6 @@ namespace Hangfire.Mongo.Tests
 
             // Act
             var result = _connection.GetSetCount(new[] { "set-1", "set-2" }, 10);
-            
 
             // Assert
             Assert.Equal(4, result);
@@ -1628,4 +1628,6 @@ namespace Hangfire.Mongo.Tests
             Assert.Equal(2, result);
         }
     }
+
+#pragma warning restore 1591
 }

--- a/src/Hangfire.Mongo.Tests/MongoConnectionFacts.cs
+++ b/src/Hangfire.Mongo.Tests/MongoConnectionFacts.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 using System.Threading;
 using Hangfire.Common;
 using Hangfire.Mongo.Database;
@@ -1627,45 +1626,6 @@ namespace Hangfire.Mongo.Tests
 
             // Assert
             Assert.Equal(2, result);
-        }
-
-        [Fact]
-        public void GetUtcDateTime_FallbacksToServerStatus_WhenAggregationReturnsNoDocuments()
-        {
-            // Arrange: empty schema collection causes aggregation path to throw and fallback to serverStatus
-            ResetStaticFlags();
-
-            // Act
-            var result = _connection.GetUtcDateTime();
-
-            // Assert – result should be close to now and flag remains true
-            Assert.True((DateTime.UtcNow - result) < TimeSpan.FromMinutes(1));
-            Assert.True((bool)typeof(MongoConnection).GetField("_useServerStatus", BindingFlags.NonPublic | BindingFlags.Static)!.GetValue(null));
-        }
-
-        [Fact]
-        public void GetUtcDateTime_FallbacksToIsMaster_WhenServerStatusThrows()
-        {
-            // Arrange: ensure flag forces direct isMaster usage
-            ResetStaticFlags();
-            var useIsMasterField = typeof(MongoConnection).GetField("_useIsMaster", BindingFlags.NonPublic | BindingFlags.Static)!;
-            useIsMasterField.SetValue(null, true);
-
-            // Act
-            var result = _connection.GetUtcDateTime();
-
-            // Assert – result should be close to now and flag remains true
-            Assert.True((DateTime.UtcNow - result) < TimeSpan.FromMinutes(1));
-            Assert.True((bool)useIsMasterField.GetValue(null)!);
-        }
-
-        private static void ResetStaticFlags()
-        {
-            var type = typeof(MongoConnection);
-            var useServerStatus = type.GetField("_useServerStatus", BindingFlags.NonPublic | BindingFlags.Static);
-            var useIsMaster = type.GetField("_useIsMaster", BindingFlags.NonPublic | BindingFlags.Static);
-            useServerStatus?.SetValue(null, false);
-            useIsMaster?.SetValue(null, false);
         }
     }
 }

--- a/src/Hangfire.Mongo.Tests/MongoConnectionUtcDateTimeFacts.cs
+++ b/src/Hangfire.Mongo.Tests/MongoConnectionUtcDateTimeFacts.cs
@@ -75,7 +75,7 @@ namespace Hangfire.Mongo.Tests
                 _value = value;
             }
 
-            public override DateTime GetUtcDateTime(HangfireDbContext dbContext, ILog logger)
+            public override DateTime GetUtcDateTime(HangfireDbContext dbContext)
             {
                 return _value;
             }
@@ -83,7 +83,7 @@ namespace Hangfire.Mongo.Tests
 
         private sealed class ThrowingUtcDateTimeStrategy : UtcDateTimeStrategy
         {
-            public override DateTime GetUtcDateTime(HangfireDbContext dbContext, ILog logger)
+            public override DateTime GetUtcDateTime(HangfireDbContext dbContext)
             {
                 throw new InvalidOperationException("strategy failed");
             }

--- a/src/Hangfire.Mongo.Tests/MongoConnectionUtcDateTimeFacts.cs
+++ b/src/Hangfire.Mongo.Tests/MongoConnectionUtcDateTimeFacts.cs
@@ -1,5 +1,4 @@
 using System;
-using Hangfire.Logging;
 using Hangfire.Mongo.Database;
 using Hangfire.Mongo.Tests.Utils;
 using Hangfire.Mongo.UtcDateTime;
@@ -25,7 +24,10 @@ namespace Hangfire.Mongo.Tests
 
             var storageOptions = new MongoStorageOptions
             {
-                UtcDateTimeStrategy = new FixedUtcDateTimeStrategy(expected)
+                UtcDateTimeStrategies =
+                [
+                    new FixedUtcDateTimeStrategy(expected)
+                ]
             };
 
             var connection = new MongoConnection(_dbContext, storageOptions);
@@ -36,29 +38,11 @@ namespace Hangfire.Mongo.Tests
         }
 
         [Fact]
-        public void GetUtcDateTime_FallsBackToAvailableStrategies_WhenConfiguredStrategyFails()
-        {
-            var fallback = new DateTime(2021, 6, 7, 8, 9, 10, DateTimeKind.Utc);
-
-            var storageOptions = new MongoStorageOptions
-            {
-                UtcDateTimeStrategy = new ThrowingUtcDateTimeStrategy(),
-                EnabledUtcDateTimeStrategies = [new FixedUtcDateTimeStrategy(fallback)]
-            };
-
-            var connection = new MongoConnection(_dbContext, storageOptions);
-
-            var now = connection.GetUtcDateTime();
-
-            Assert.Equal(fallback, now);
-        }
-
-        [Fact]
         public void GetUtcDateTime_ThrowsInvalidOperation_WhenAllStrategiesFail()
         {
             var storageOptions = new MongoStorageOptions
             {
-                EnabledUtcDateTimeStrategies = [new ThrowingUtcDateTimeStrategy(), new ThrowingUtcDateTimeStrategy()]
+                UtcDateTimeStrategies = [new ThrowingUtcDateTimeStrategy(), new ThrowingUtcDateTimeStrategy()]
             };
 
             var connection = new MongoConnection(_dbContext, storageOptions);

--- a/src/Hangfire.Mongo.Tests/MongoConnectionUtcDateTimeFacts.cs
+++ b/src/Hangfire.Mongo.Tests/MongoConnectionUtcDateTimeFacts.cs
@@ -1,0 +1,92 @@
+using System;
+using Hangfire.Logging;
+using Hangfire.Mongo.Database;
+using Hangfire.Mongo.Tests.Utils;
+using Hangfire.Mongo.UtcDateTime;
+using Xunit;
+
+namespace Hangfire.Mongo.Tests
+{
+    [Collection("Database")]
+    public class MongoConnectionUtcDateTimeFacts
+    {
+        private readonly HangfireDbContext _dbContext;
+
+        public MongoConnectionUtcDateTimeFacts(MongoIntegrationTestFixture fixture)
+        {
+            fixture.CleanDatabase();
+            _dbContext = fixture.CreateDbContext();
+        }
+
+        [Fact]
+        public void GetUtcDateTime_ReturnsValueFromConfiguredStrategy()
+        {
+            var expected = new DateTime(2020, 1, 2, 3, 4, 5, DateTimeKind.Utc);
+
+            var storageOptions = new MongoStorageOptions
+            {
+                UtcDateTimeStrategy = new FixedUtcDateTimeStrategy(expected)
+            };
+
+            var connection = new MongoConnection(_dbContext, storageOptions);
+
+            var now = connection.GetUtcDateTime();
+
+            Assert.Equal(expected, now);
+        }
+
+        [Fact]
+        public void GetUtcDateTime_FallsBackToAvailableStrategies_WhenConfiguredStrategyFails()
+        {
+            var fallback = new DateTime(2021, 6, 7, 8, 9, 10, DateTimeKind.Utc);
+
+            var storageOptions = new MongoStorageOptions
+            {
+                UtcDateTimeStrategy = new ThrowingUtcDateTimeStrategy(),
+                EnabledUtcDateTimeStrategies = [new FixedUtcDateTimeStrategy(fallback)]
+            };
+
+            var connection = new MongoConnection(_dbContext, storageOptions);
+
+            var now = connection.GetUtcDateTime();
+
+            Assert.Equal(fallback, now);
+        }
+
+        [Fact]
+        public void GetUtcDateTime_ThrowsInvalidOperation_WhenAllStrategiesFail()
+        {
+            var storageOptions = new MongoStorageOptions
+            {
+                EnabledUtcDateTimeStrategies = [new ThrowingUtcDateTimeStrategy(), new ThrowingUtcDateTimeStrategy()]
+            };
+
+            var connection = new MongoConnection(_dbContext, storageOptions);
+
+            Assert.Throws<InvalidOperationException>(() => connection.GetUtcDateTime());
+        }
+
+        private sealed class FixedUtcDateTimeStrategy : UtcDateTimeStrategy
+        {
+            private readonly DateTime _value;
+
+            public FixedUtcDateTimeStrategy(DateTime value)
+            {
+                _value = value;
+            }
+
+            public override DateTime GetUtcDateTime(HangfireDbContext dbContext, ILog logger)
+            {
+                return _value;
+            }
+        }
+
+        private sealed class ThrowingUtcDateTimeStrategy : UtcDateTimeStrategy
+        {
+            public override DateTime GetUtcDateTime(HangfireDbContext dbContext, ILog logger)
+            {
+                throw new InvalidOperationException("strategy failed");
+            }
+        }
+    }
+}

--- a/src/Hangfire.Mongo/DocumentDB/DocumentDbConnection.cs
+++ b/src/Hangfire.Mongo/DocumentDB/DocumentDbConnection.cs
@@ -1,0 +1,13 @@
+﻿using Hangfire.Mongo.Database;
+
+namespace Hangfire.Mongo.DocumentDB;
+
+///  <inheritdoc />
+public class DocumentDbConnection : MongoConnection
+{
+    /// <inheritdoc />
+    public DocumentDbConnection(HangfireDbContext database, DocumentDbStorageOptions storageOptions)
+        : base(database, storageOptions)
+    {
+    }
+}

--- a/src/Hangfire.Mongo/DocumentDB/DocumentDbStorageOptions.cs
+++ b/src/Hangfire.Mongo/DocumentDB/DocumentDbStorageOptions.cs
@@ -14,7 +14,7 @@ namespace Hangfire.Mongo.DocumentDB
             : base()
         {
             // Restrict UTC date/time strategy to the isMaster command, which is supported by DocumentDB unprivileged users.
-            EnabledUtcDateTimeStrategies =
+            UtcDateTimeStrategies =
             [
                 new IsMasterUtcDateTimeStrategy()
             ];

--- a/src/Hangfire.Mongo/DocumentDB/DocumentDbStorageOptions.cs
+++ b/src/Hangfire.Mongo/DocumentDB/DocumentDbStorageOptions.cs
@@ -1,0 +1,23 @@
+using Hangfire.Mongo.UtcDateTime;
+
+namespace Hangfire.Mongo.DocumentDB
+{
+    /// <summary>
+    /// Storage options preconfigured for use with AWS DocumentDB servers
+    /// </summary>
+    public class DocumentDbStorageOptions : MongoStorageOptions
+    {
+        /// <summary>
+        /// Constructs DocumentDB-specific storage options.
+        /// </summary>
+        public DocumentDbStorageOptions()
+            : base()
+        {
+            // Restrict UTC date/time strategy to the isMaster command, which is supported by DocumentDB unprivileged users.
+            EnabledUtcDateTimeStrategies =
+            [
+                new IsMasterUtcDateTimeStrategy()
+            ];
+        }
+    }
+}

--- a/src/Hangfire.Mongo/MongoConnection.cs
+++ b/src/Hangfire.Mongo/MongoConnection.cs
@@ -686,7 +686,7 @@ namespace Hangfire.Mongo
             {
                 if (currentStrategy != null)
                 {
-                    return currentStrategy.GetUtcDateTime(_dbContext, Logger);
+                    return currentStrategy.GetUtcDateTime(_dbContext);
                 }
             }
             catch (Exception ex)
@@ -710,7 +710,7 @@ namespace Hangfire.Mongo
             {
                 try
                 {
-                    DateTime now = strategy.GetUtcDateTime(_dbContext, Logger);
+                    DateTime now = strategy.GetUtcDateTime(_dbContext);
 
                     if (Logger.IsTraceEnabled())
                     {
@@ -725,6 +725,8 @@ namespace Hangfire.Mongo
                     {
                         Logger.Warn($"Failed to get UTC datetime using {strategy.GetType().Name}: {ex.Message}");
                     }
+
+                    lastError = ex;
                 }
             }
 

--- a/src/Hangfire.Mongo/MongoConnection.cs
+++ b/src/Hangfire.Mongo/MongoConnection.cs
@@ -680,29 +680,7 @@ namespace Hangfire.Mongo
 
         public override DateTime GetUtcDateTime()
         {
-            UtcDateTimeStrategy currentStrategy = _storageOptions.UtcDateTimeStrategy;
-
-            try
-            {
-                if (currentStrategy != null)
-                {
-                    return currentStrategy.GetUtcDateTime(_dbContext);
-                }
-            }
-            catch (Exception ex)
-            {
-                if (Logger.IsWarnEnabled())
-                {
-                    Logger.Warn($"Failed to get UTC datetime using the configured strategy, falling back to other available strategies: {ex.Message}");
-                }
-            }
-
-            var availableStrategies = _storageOptions.EnabledUtcDateTimeStrategies;
-
-            if (currentStrategy != null)
-            {
-                availableStrategies = [.. availableStrategies.Except([currentStrategy])];
-            }
+            var availableStrategies = _storageOptions.UtcDateTimeStrategies;
 
             Exception lastError = null;
 
@@ -710,7 +688,7 @@ namespace Hangfire.Mongo
             {
                 try
                 {
-                    DateTime now = strategy.GetUtcDateTime(_dbContext);
+                    var now = strategy.GetUtcDateTime(_dbContext);
 
                     if (Logger.IsTraceEnabled())
                     {

--- a/src/Hangfire.Mongo/MongoMigrationOptions.cs
+++ b/src/Hangfire.Mongo/MongoMigrationOptions.cs
@@ -96,5 +96,5 @@ namespace Hangfire.Mongo
                 _backupPostfix = value;
             }
         }
-    }         
+    }
 }

--- a/src/Hangfire.Mongo/MongoStorageOptions.cs
+++ b/src/Hangfire.Mongo/MongoStorageOptions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Hangfire.Mongo.UtcDateTime;
 
 namespace Hangfire.Mongo
 {
@@ -14,6 +15,7 @@ namespace Hangfire.Mongo
         private TimeSpan _migrationLockTimeout;
         private MongoMigrationOptions _migrationOptions;
         private MongoFactory _factory;
+        private UtcDateTimeStrategy[] _enabledUtcDateTimeStrategies;
         private string _prefix;
 
         /// <summary>
@@ -37,6 +39,12 @@ namespace Hangfire.Mongo
             MigrationOptions = new MongoMigrationOptions();
             Factory = new MongoFactory();
             CheckQueuedJobsStrategy = CheckQueuedJobsStrategy.Watch;
+
+            _enabledUtcDateTimeStrategies =
+            [
+                new AggregationUtcDateTimeStrategy(),
+                new ServerStatusUtcDateTimeStrategy(),
+            ];
         }
 
         /// <summary>
@@ -208,5 +216,26 @@ namespace Hangfire.Mongo
                 _migrationOptions = value;
             }
         }
+
+        /// <summary>
+        /// Array of enabled strategies for obtaining UTC date and time.
+        /// </summary>
+        public UtcDateTimeStrategy[] EnabledUtcDateTimeStrategies
+        {
+            get => _enabledUtcDateTimeStrategies;
+            set
+            {
+                if (value == null)
+                {
+                    throw new ArgumentException($"'{EnabledUtcDateTimeStrategies}' cannot be null");
+                }
+                _enabledUtcDateTimeStrategies = value;
+            }
+        }
+
+        /// <summary>
+        /// Custom strategy for resolving UTC time from MongoDB
+        /// </summary>
+        public UtcDateTimeStrategy UtcDateTimeStrategy { get; set; }
     }
 }

--- a/src/Hangfire.Mongo/MongoStorageOptions.cs
+++ b/src/Hangfire.Mongo/MongoStorageOptions.cs
@@ -15,7 +15,7 @@ namespace Hangfire.Mongo
         private TimeSpan _migrationLockTimeout;
         private MongoMigrationOptions _migrationOptions;
         private MongoFactory _factory;
-        private UtcDateTimeStrategy[] _enabledUtcDateTimeStrategies;
+        private UtcDateTimeStrategy[] _utcDateTimeStrategies;
         private string _prefix;
 
         /// <summary>
@@ -40,7 +40,7 @@ namespace Hangfire.Mongo
             Factory = new MongoFactory();
             CheckQueuedJobsStrategy = CheckQueuedJobsStrategy.Watch;
 
-            _enabledUtcDateTimeStrategies =
+            _utcDateTimeStrategies =
             [
                 new AggregationUtcDateTimeStrategy(),
                 new ServerStatusUtcDateTimeStrategy(),
@@ -220,22 +220,17 @@ namespace Hangfire.Mongo
         /// <summary>
         /// Array of enabled strategies for obtaining UTC date and time.
         /// </summary>
-        public UtcDateTimeStrategy[] EnabledUtcDateTimeStrategies
+        public UtcDateTimeStrategy[] UtcDateTimeStrategies
         {
-            get => _enabledUtcDateTimeStrategies;
+            get => _utcDateTimeStrategies;
             set
             {
                 if (value == null)
                 {
-                    throw new ArgumentException($"'{EnabledUtcDateTimeStrategies}' cannot be null");
+                    throw new ArgumentException($"'{UtcDateTimeStrategies}' cannot be null");
                 }
-                _enabledUtcDateTimeStrategies = value;
+                _utcDateTimeStrategies = value;
             }
         }
-
-        /// <summary>
-        /// Custom strategy for resolving UTC time from MongoDB
-        /// </summary>
-        public UtcDateTimeStrategy UtcDateTimeStrategy { get; set; }
     }
 }

--- a/src/Hangfire.Mongo/UtcDateTime/AggregationUtcDateTimeStrategy.cs
+++ b/src/Hangfire.Mongo/UtcDateTime/AggregationUtcDateTimeStrategy.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Linq;
-using Hangfire.Logging;
 using Hangfire.Mongo.Database;
 using MongoDB.Bson;
 using MongoDB.Driver;
@@ -16,9 +15,8 @@ namespace Hangfire.Mongo.UtcDateTime
         /// Obtain current UTC time using the aggregate pipeline with $$NOW.
         /// </summary>
         /// <param name="dbContext">MongoDB context.</param>
-        /// <param name="logger">Logger instance.</param>
         /// <returns>The UTC time reported by MongoDB.</returns>
-        public override DateTime GetUtcDateTime(HangfireDbContext dbContext, ILog logger)
+        public override DateTime GetUtcDateTime(HangfireDbContext dbContext)
         {
             var pipeline = new[]
             {

--- a/src/Hangfire.Mongo/UtcDateTime/AggregationUtcDateTimeStrategy.cs
+++ b/src/Hangfire.Mongo/UtcDateTime/AggregationUtcDateTimeStrategy.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Linq;
+using Hangfire.Logging;
+using Hangfire.Mongo.Database;
+using MongoDB.Bson;
+using MongoDB.Driver;
+
+namespace Hangfire.Mongo.UtcDateTime
+{
+    /// <summary>
+    /// Uses an aggregation pipeline on the Schema collection to retrieve server time.
+    /// </summary>
+    public sealed class AggregationUtcDateTimeStrategy : UtcDateTimeStrategy
+    {
+        /// <summary>
+        /// Obtain current UTC time using the aggregate pipeline with $$NOW.
+        /// </summary>
+        /// <param name="dbContext">MongoDB context.</param>
+        /// <param name="logger">Logger instance.</param>
+        /// <returns>The UTC time reported by MongoDB.</returns>
+        public override DateTime GetUtcDateTime(HangfireDbContext dbContext, ILog logger)
+        {
+            var pipeline = new[]
+            {
+                new BsonDocument("$project", new BsonDocument("date", "$$NOW"))
+            };
+
+            var time = dbContext.Schema.Aggregate<BsonDocument>(pipeline).FirstOrDefault();
+            if (time is null)
+            {
+                throw new InvalidOperationException("No documents in the schema collection");
+            }
+
+            return time["date"].ToUniversalTime();
+        }
+    }
+}

--- a/src/Hangfire.Mongo/UtcDateTime/IsMasterUtcDateTimeStrategy.cs
+++ b/src/Hangfire.Mongo/UtcDateTime/IsMasterUtcDateTimeStrategy.cs
@@ -1,0 +1,25 @@
+using System;
+using Hangfire.Logging;
+using Hangfire.Mongo.Database;
+using MongoDB.Bson;
+
+namespace Hangfire.Mongo.UtcDateTime
+{
+    /// <summary>
+    /// Uses the isMaster command to retrieve server time.
+    /// </summary>
+    public sealed class IsMasterUtcDateTimeStrategy : UtcDateTimeStrategy
+    {
+        /// <summary>
+        /// Obtain current UTC time using the isMaster command.
+        /// </summary>
+        /// <param name="dbContext">MongoDB context.</param>
+        /// <param name="logger">Logger instance.</param>
+        /// <returns>The UTC time reported by MongoDB.</returns>
+        public override DateTime GetUtcDateTime(HangfireDbContext dbContext, ILog logger)
+        {
+            var isMaster = dbContext.Database.RunCommand<BsonDocument>(new BsonDocument("isMaster", 1));
+            return isMaster["localTime"].ToUniversalTime();
+        }
+    }
+}

--- a/src/Hangfire.Mongo/UtcDateTime/IsMasterUtcDateTimeStrategy.cs
+++ b/src/Hangfire.Mongo/UtcDateTime/IsMasterUtcDateTimeStrategy.cs
@@ -1,5 +1,4 @@
 using System;
-using Hangfire.Logging;
 using Hangfire.Mongo.Database;
 using MongoDB.Bson;
 
@@ -14,9 +13,8 @@ namespace Hangfire.Mongo.UtcDateTime
         /// Obtain current UTC time using the isMaster command.
         /// </summary>
         /// <param name="dbContext">MongoDB context.</param>
-        /// <param name="logger">Logger instance.</param>
         /// <returns>The UTC time reported by MongoDB.</returns>
-        public override DateTime GetUtcDateTime(HangfireDbContext dbContext, ILog logger)
+        public override DateTime GetUtcDateTime(HangfireDbContext dbContext)
         {
             var isMaster = dbContext.Database.RunCommand<BsonDocument>(new BsonDocument("isMaster", 1));
             return isMaster["localTime"].ToUniversalTime();

--- a/src/Hangfire.Mongo/UtcDateTime/ServerStatusUtcDateTimeStrategy.cs
+++ b/src/Hangfire.Mongo/UtcDateTime/ServerStatusUtcDateTimeStrategy.cs
@@ -1,0 +1,25 @@
+using System;
+using Hangfire.Logging;
+using Hangfire.Mongo.Database;
+using MongoDB.Bson;
+
+namespace Hangfire.Mongo.UtcDateTime
+{
+    /// <summary>
+    /// Uses the serverStatus command to retrieve server time.
+    /// </summary>
+    public sealed class ServerStatusUtcDateTimeStrategy : UtcDateTimeStrategy
+    {
+        /// <summary>
+        /// Obtain current UTC time using the serverStatus command.
+        /// </summary>
+        /// <param name="dbContext">MongoDB context.</param>
+        /// <param name="logger">Logger instance.</param>
+        /// <returns>The UTC time reported by MongoDB.</returns>
+        public override DateTime GetUtcDateTime(HangfireDbContext dbContext, ILog logger)
+        {
+            var serverStatus = dbContext.Database.RunCommand<BsonDocument>(new BsonDocument("serverStatus", 1));
+            return serverStatus["localTime"].ToUniversalTime();
+        }
+    }
+}

--- a/src/Hangfire.Mongo/UtcDateTime/ServerStatusUtcDateTimeStrategy.cs
+++ b/src/Hangfire.Mongo/UtcDateTime/ServerStatusUtcDateTimeStrategy.cs
@@ -1,5 +1,4 @@
 using System;
-using Hangfire.Logging;
 using Hangfire.Mongo.Database;
 using MongoDB.Bson;
 
@@ -14,9 +13,8 @@ namespace Hangfire.Mongo.UtcDateTime
         /// Obtain current UTC time using the serverStatus command.
         /// </summary>
         /// <param name="dbContext">MongoDB context.</param>
-        /// <param name="logger">Logger instance.</param>
         /// <returns>The UTC time reported by MongoDB.</returns>
-        public override DateTime GetUtcDateTime(HangfireDbContext dbContext, ILog logger)
+        public override DateTime GetUtcDateTime(HangfireDbContext dbContext)
         {
             var serverStatus = dbContext.Database.RunCommand<BsonDocument>(new BsonDocument("serverStatus", 1));
             return serverStatus["localTime"].ToUniversalTime();

--- a/src/Hangfire.Mongo/UtcDateTime/UtcDateTimeStrategy.cs
+++ b/src/Hangfire.Mongo/UtcDateTime/UtcDateTimeStrategy.cs
@@ -1,5 +1,4 @@
 using System;
-using Hangfire.Logging;
 using Hangfire.Mongo.Database;
 
 namespace Hangfire.Mongo.UtcDateTime
@@ -13,8 +12,7 @@ namespace Hangfire.Mongo.UtcDateTime
         /// Obtain current UTC time using the provided MongoDB context.
         /// </summary>
         /// <param name="dbContext">MongoDB context.</param>
-        /// <param name="logger">Logger instance.</param>
         /// <returns>UTC DateTime.</returns>
-        public abstract DateTime GetUtcDateTime(HangfireDbContext dbContext, ILog logger);
+        public abstract DateTime GetUtcDateTime(HangfireDbContext dbContext);
     }
 }

--- a/src/Hangfire.Mongo/UtcDateTime/UtcDateTimeStrategy.cs
+++ b/src/Hangfire.Mongo/UtcDateTime/UtcDateTimeStrategy.cs
@@ -1,0 +1,20 @@
+using System;
+using Hangfire.Logging;
+using Hangfire.Mongo.Database;
+
+namespace Hangfire.Mongo.UtcDateTime
+{
+    /// <summary>
+    /// Strategy for obtaining UTC time from MongoDB server
+    /// </summary>
+    public abstract class UtcDateTimeStrategy
+    {
+        /// <summary>
+        /// Obtain current UTC time using the provided MongoDB context.
+        /// </summary>
+        /// <param name="dbContext">MongoDB context.</param>
+        /// <param name="logger">Logger instance.</param>
+        /// <returns>UTC DateTime.</returns>
+        public abstract DateTime GetUtcDateTime(HangfireDbContext dbContext, ILog logger);
+    }
+}


### PR DESCRIPTION
Implement retrieval of UTC time using the 'isMaster' command in MongoConnection to enhance compatibility with AWS DocumentDB.