### PR TITLE
v1.12.0

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,13 @@
 
 ## Change log
 
+### v1.12.0
+- Update to Hangfire.Core v1.8.21
+- Add UTC time support for AWS DocumentDB compatibility #431 (thiago-boche)
+- Add UtcDateTimeStrategy to MongoStorage so users can write their own if needed #431 (thiago-boche)
+- Use IsMasterUtcDateTimeStrategy for CosmosStorageOptions. (can be overriden)
+- Added bootstrapper extensions and convenience classes for configuring documentdb
+
 ### v1.11.7
 - Update to MongoDB.Driver v3.4.2
 

--- a/src/Hangfire.Mongo.Sample.ASPNetCore/Hangfire.Mongo.Sample.ASPNetCore.csproj
+++ b/src/Hangfire.Mongo.Sample.ASPNetCore/Hangfire.Mongo.Sample.ASPNetCore.csproj
@@ -20,12 +20,12 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="bootstrap" Version="5.3.7" />
-    <PackageReference Include="Hangfire.AspNetCore" Version="1.8.20" />
-    <PackageReference Include="Hangfire.Core" Version="1.8.20" />
+    <PackageReference Include="Hangfire.AspNetCore" Version="1.8.21" />
+    <PackageReference Include="Hangfire.Core" Version="1.8.21" />
     <PackageReference Include="jquery" Version="3.7.1" />
     <PackageReference Include="MongoDB.Driver" Version="3.4.2" />
     <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.8" />
     <PackageReference Include="Testcontainers.MongoDb" Version="4.6.0" />
   </ItemGroup>
 </Project>

--- a/src/Hangfire.Mongo.Sample.CosmosDB/Hangfire.Mongo.Sample.CosmosDB.csproj
+++ b/src/Hangfire.Mongo.Sample.CosmosDB/Hangfire.Mongo.Sample.CosmosDB.csproj
@@ -20,12 +20,12 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="bootstrap" Version="5.3.7" />
-    <PackageReference Include="Hangfire.AspNetCore" Version="1.8.20" />
-    <PackageReference Include="Hangfire.Core" Version="1.8.20" />
+    <PackageReference Include="Hangfire.AspNetCore" Version="1.8.21" />
+    <PackageReference Include="Hangfire.Core" Version="1.8.21" />
     <PackageReference Include="jquery" Version="3.7.1" />
     <PackageReference Include="MongoDB.Driver" Version="3.4.2" />
     <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.8" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 </Project>

--- a/src/Hangfire.Mongo.Sample.NETCore/Hangfire.Mongo.Sample.NETCore.csproj
+++ b/src/Hangfire.Mongo.Sample.NETCore/Hangfire.Mongo.Sample.NETCore.csproj
@@ -18,7 +18,7 @@
     <ProjectReference Include="..\Hangfire.Mongo\Hangfire.Mongo.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Hangfire.Core" Version="1.8.20" />
+    <PackageReference Include="Hangfire.Core" Version="1.8.21" />
     <PackageReference Include="MongoDB.Driver" Version="3.4.2" />
     <PackageReference Include="Testcontainers.MongoDb" Version="4.6.0" />
   </ItemGroup>

--- a/src/Hangfire.Mongo.Tests/Hangfire.Mongo.Tests.csproj
+++ b/src/Hangfire.Mongo.Tests/Hangfire.Mongo.Tests.csproj
@@ -27,11 +27,11 @@
     <ProjectReference Include="../Hangfire.Mongo/Hangfire.Mongo.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.8" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="Testcontainers.MongoDb" Version="4.6.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.3">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Hangfire.Mongo/CosmosDB/CosmosConnection.cs
+++ b/src/Hangfire.Mongo/CosmosDB/CosmosConnection.cs
@@ -11,10 +11,4 @@ public class CosmosConnection : MongoConnection
         : base(database, storageOptions)
     {
     }
-
-    /// <inheritdoc />
-    public override DateTime GetUtcDateTime()
-    {
-        return DateTime.UtcNow;
-    }
 }

--- a/src/Hangfire.Mongo/CosmosDB/CosmosStorage.cs
+++ b/src/Hangfire.Mongo/CosmosDB/CosmosStorage.cs
@@ -25,22 +25,6 @@ namespace Hangfire.Mongo.CosmosDB
             {
                 throw new ArgumentException("CosmosDB does not support capped collections");
             }
-            Features = new ReadOnlyDictionary<string, bool>(
-                new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase)
-                {
-                    {JobStorageFeatures.ExtendedApi, true},
-                    {JobStorageFeatures.JobQueueProperty, true},
-                    {JobStorageFeatures.ProcessesInsteadOfComponents, true},
-                    {JobStorageFeatures.Connection.BatchedGetFirstByLowest, true},
-                    {JobStorageFeatures.Connection.GetUtcDateTime, false},
-                    {JobStorageFeatures.Connection.GetSetContains, true},
-                    {JobStorageFeatures.Connection.LimitedGetSetCount, true},
-                    {JobStorageFeatures.Transaction.AcquireDistributedLock, true},
-                    {JobStorageFeatures.Transaction.CreateJob, true},
-                    {JobStorageFeatures.Transaction.SetJobParameter, true},
-                    {JobStorageFeatures.Monitoring.DeletedStateGraphs, true},
-                    {JobStorageFeatures.Monitoring.AwaitingJobs, true}
-                });
         }
 
         /// <inheritdoc />

--- a/src/Hangfire.Mongo/CosmosDB/CosmosStorageOptions.cs
+++ b/src/Hangfire.Mongo/CosmosDB/CosmosStorageOptions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Hangfire.Mongo.UtcDateTime;
 
 namespace Hangfire.Mongo.CosmosDB
 {
@@ -17,6 +18,10 @@ namespace Hangfire.Mongo.CosmosDB
             MigrationLockTimeout = TimeSpan.FromMinutes(2);
             Factory = new CosmosFactory();
             SupportsCappedCollection = false;
+            UtcDateTimeStrategies =
+            [
+                new IsMasterUtcDateTimeStrategy()
+            ];
         }
     }
 }

--- a/src/Hangfire.Mongo/DocumentDB/DocumentDbBootstrapperConfigurationExtensions.cs
+++ b/src/Hangfire.Mongo/DocumentDB/DocumentDbBootstrapperConfigurationExtensions.cs
@@ -1,0 +1,30 @@
+﻿using MongoDB.Driver;
+
+namespace Hangfire.Mongo.DocumentDB
+{
+    /// <summary>
+    /// Represents extensions to configure CosmosDB storage for Hangfire
+    /// </summary>
+    public static class DocumentDbBootstrapperConfigurationExtensions
+    {
+        /// <summary>
+        /// Configure Hangfire to use CosmosDB storage
+        /// </summary>
+        /// <param name="configuration">Configuration</param>
+        /// <param name="mongoClient">Client for Mongo</param>
+        /// <param name="databaseName">Name of database</param>
+        /// <param name="storageOptions">Storage options</param>
+        /// <returns></returns>
+        public static DocumentDbStorage UseDocumentDbStorage(this IGlobalConfiguration configuration,
+            IMongoClient mongoClient,
+            string databaseName,
+            DocumentDbStorageOptions storageOptions)
+        {
+            var storage = new DocumentDbStorage(mongoClient, databaseName, storageOptions);
+
+            configuration.UseStorage(storage);
+
+            return storage;
+        }
+    }
+}

--- a/src/Hangfire.Mongo/DocumentDB/DocumentDbStorage.cs
+++ b/src/Hangfire.Mongo/DocumentDB/DocumentDbStorage.cs
@@ -1,0 +1,20 @@
+﻿using MongoDB.Driver;
+
+namespace Hangfire.Mongo.DocumentDB;
+
+/// <summary>
+/// Cosmos DB storage
+/// </summary>
+public class DocumentDbStorage : MongoStorage
+{
+    /// <summary>
+    /// ctor
+    /// </summary>
+    /// <param name="mongoClient"></param>
+    /// <param name="databaseName"></param>
+    /// <param name="storageOptions"></param>
+    public DocumentDbStorage(IMongoClient mongoClient, string databaseName, DocumentDbStorageOptions storageOptions)
+        : base(mongoClient, databaseName, storageOptions)
+    {
+    }
+}

--- a/src/Hangfire.Mongo/Hangfire.Mongo.csproj
+++ b/src/Hangfire.Mongo/Hangfire.Mongo.csproj
@@ -12,8 +12,12 @@
         <owners>Jonas Gottschau</owners>
         <Description>MongoDB storage implementation for Hangfire (background job system for ASP.NET applications).</Description>
         <PackageTags>Hangfire AspNet OWIN MongoDB CosmosDB Long-Running Background Fire-And-Forget Delayed Recurring Tasks Jobs Scheduler Threading Queues</PackageTags>
-        <PackageReleaseNotes>1.11.7
-            - Update to MongoDB.Driver v3.4.2
+        <PackageReleaseNotes>1.12.0
+            - Update to Hangfire.Core v1.8.21
+            - Add UTC time support for AWS DocumentDB compatibility #431 (thiago-boche)
+            - Add UtcDateTimeStrategy to MongoStorage so users can write their own if needed #431 (thiago-boche)
+            - Use IsMasterUtcDateTimeStrategy for CosmosStorageOptions. (can be overriden)
+            - Added bootstrapper extensions and convenience classes for configuring documentdb
         </PackageReleaseNotes>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <!--<PackageLicenseUrl>https://raw.githubusercontent.com/sergun/Hangfire.Mongo/master/LICENSE</PackageLicenseUrl>-->
@@ -25,7 +29,7 @@
         <None Include="../../README.md" pack="true" PackagePath="." />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Hangfire.Core" Version="1.8.20" />
+        <PackageReference Include="Hangfire.Core" Version="1.8.21" />
         <PackageReference Include="MongoDB.Driver" Version="3.4.2" />
     </ItemGroup>
     <ItemGroup>


### PR DESCRIPTION
- Update to Hangfire.Core v1.8.21
- Add UTC time support for AWS DocumentDB compatibility #431 (thiago-boche)
- Add UtcDateTimeStrategy to MongoStorage so users can write their own if needed #431 (thiago-boche)
- Use IsMasterUtcDateTimeStrategy for CosmosStorageOptions. (can be overriden)
- Added bootstrapper extensions and convenience classes for configuring documentdb